### PR TITLE
[Feat/#9] 사용자 자산 등록

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,10 +28,12 @@ dependencies {
     // Spring boot
     implementation("org.springframework.boot:spring-boot-starter-webmvc")
     implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("org.springframework.boot:spring-boot-starter-validation")
 
     // Test
     testImplementation("org.springframework.boot:spring-boot-starter-webmvc-test")
     testImplementation("org.springframework.boot:spring-boot-starter-data-jpa-test")
+    testImplementation("io.rest-assured:rest-assured:6.0.0")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
     // H2

--- a/src/main/java/com/journeyprint/common/exception/ApiException.java
+++ b/src/main/java/com/journeyprint/common/exception/ApiException.java
@@ -1,0 +1,8 @@
+package com.journeyprint.common.exception;
+
+public class ApiException extends RuntimeException {
+    public ApiException(String message) {
+        super(message);
+    }
+
+}

--- a/src/main/java/com/journeyprint/common/web/ApiControllerAdvice.java
+++ b/src/main/java/com/journeyprint/common/web/ApiControllerAdvice.java
@@ -1,0 +1,34 @@
+package com.journeyprint.common.web;
+
+import com.journeyprint.common.exception.ApiException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ApiControllerAdvice {
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(BindException.class)
+    public ResponseEntity<ApiResponse<Void>> bindException(BindException e) {
+        return ApiResponse.of(
+                HttpStatus.BAD_REQUEST,
+                e.getBindingResult().getAllErrors().getFirst().getDefaultMessage(),
+                null
+        );
+    }
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler(ApiException.class)
+    public ResponseEntity<ApiResponse<Void>> apiException(ApiException e) {
+        return ApiResponse.of(
+                HttpStatus.BAD_REQUEST,
+                e.getMessage(),
+                null
+        );
+    }
+
+}

--- a/src/main/java/com/journeyprint/common/web/ApiResponse.java
+++ b/src/main/java/com/journeyprint/common/web/ApiResponse.java
@@ -1,0 +1,40 @@
+package com.journeyprint.common.web;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+public class ApiResponse<T> {
+
+    private final int code;
+    private final HttpStatus status;
+    private final String message;
+    private final T data;
+
+    private ApiResponse(HttpStatus status, String message, T data) {
+        this.code = status.value();
+        this.status = status;
+        this.message = message;
+        this.data = data;
+    }
+
+    public static <T> ResponseEntity<ApiResponse<T>> of(HttpStatus status, String message, T data) {
+        ApiResponse<T> body = new ApiResponse<>(status, message, data);
+
+        return ResponseEntity
+                .status(status)
+                .body(body);
+    }
+
+    public static <T> ResponseEntity<ApiResponse<T>> noContent() {
+        HttpStatus status = HttpStatus.NO_CONTENT;
+        ApiResponse<T> body = new ApiResponse<>(status, null, null);
+
+        return ResponseEntity
+                .status(status)
+                .body(body);
+    }
+
+    public static <T> ResponseEntity<ApiResponse<T>> ok(T data) {
+        return of(HttpStatus.OK, "Success", data);
+    }
+}

--- a/src/main/java/com/journeyprint/payment/application/PaymentService.java
+++ b/src/main/java/com/journeyprint/payment/application/PaymentService.java
@@ -1,0 +1,25 @@
+package com.journeyprint.payment.application;
+
+import com.journeyprint.common.exception.ApiException;
+import com.journeyprint.payment.application.request.PaymentCreateServiceRequest;
+import com.journeyprint.payment.domain.PaymentRepository;
+import com.journeyprint.profile.domain.ProfileRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PaymentService {
+
+    private final ProfileRepository profileRepository;
+    private final PaymentRepository paymentRepository;
+
+    public void createPayment(PaymentCreateServiceRequest request) {
+        // TODO: ProfileService 검증 로직으로 변경 필요 && 프로필에서 CustomExcpetion 생성하여 던지기
+        if (profileRepository.getById(request.profileId()).isEmpty()) {
+            throw new ApiException("Profile not found");
+        }
+
+        paymentRepository.save(request.toEntity());
+    }
+}

--- a/src/main/java/com/journeyprint/payment/application/request/PaymentCreateServiceRequest.java
+++ b/src/main/java/com/journeyprint/payment/application/request/PaymentCreateServiceRequest.java
@@ -1,0 +1,10 @@
+package com.journeyprint.payment.application.request;
+
+import com.journeyprint.payment.domain.Payment;
+
+public record PaymentCreateServiceRequest(Long profileId, String name, String description) {
+
+    public Payment toEntity() {
+        return Payment.of(profileId, name, description);
+    }
+}

--- a/src/main/java/com/journeyprint/payment/domain/Payment.java
+++ b/src/main/java/com/journeyprint/payment/domain/Payment.java
@@ -1,0 +1,51 @@
+package com.journeyprint.payment.domain;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "payments")
+@NoArgsConstructor(access = PROTECTED)
+public class Payment {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @Column(name = "profile_id", nullable = false)
+    private Long profileId;
+
+    @Column(name = "name", nullable = false, length = 30)
+    private String name;
+
+    @Column(name = "description", length = 100)
+    private String description;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    private Payment(Long profileId, String name, String description) {
+        this.profileId = profileId;
+        this.name = name;
+        this.description = description;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public static Payment of(Long profileId, String name, String description) {
+        return new Payment(profileId, name, description);
+    }
+}

--- a/src/main/java/com/journeyprint/payment/domain/PaymentRepository.java
+++ b/src/main/java/com/journeyprint/payment/domain/PaymentRepository.java
@@ -1,0 +1,9 @@
+package com.journeyprint.payment.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+
+}

--- a/src/main/java/com/journeyprint/payment/web/PaymentsController.java
+++ b/src/main/java/com/journeyprint/payment/web/PaymentsController.java
@@ -1,0 +1,24 @@
+package com.journeyprint.payment.web;
+
+import com.journeyprint.common.web.ApiResponse;
+import com.journeyprint.payment.application.PaymentService;
+import com.journeyprint.payment.web.request.PaymentCreateRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class PaymentsController {
+
+    private final PaymentService paymentService;
+
+    @PostMapping("/api/payments")
+    ResponseEntity<ApiResponse<Void>> createPayment(@Valid @RequestBody PaymentCreateRequest request) {
+        paymentService.createPayment(request.toCommand());
+        return ApiResponse.noContent();
+    }
+}

--- a/src/main/java/com/journeyprint/payment/web/PaymentsController.java
+++ b/src/main/java/com/journeyprint/payment/web/PaymentsController.java
@@ -18,7 +18,7 @@ public class PaymentsController {
 
     @PostMapping("/api/payments")
     ResponseEntity<ApiResponse<Void>> createPayment(@Valid @RequestBody PaymentCreateRequest request) {
-        paymentService.createPayment(request.toCommand());
+        paymentService.createPayment(request.toServiceRequest());
         return ApiResponse.noContent();
     }
 }

--- a/src/main/java/com/journeyprint/payment/web/request/PaymentCreateRequest.java
+++ b/src/main/java/com/journeyprint/payment/web/request/PaymentCreateRequest.java
@@ -11,7 +11,7 @@ public record PaymentCreateRequest(
         @Size(max = 100) String description
 ) {
 
-    public PaymentCreateServiceRequest toCommand() {
+    public PaymentCreateServiceRequest toServiceRequest() {
         return new PaymentCreateServiceRequest(profileId, name, description);
     }
 }

--- a/src/main/java/com/journeyprint/payment/web/request/PaymentCreateRequest.java
+++ b/src/main/java/com/journeyprint/payment/web/request/PaymentCreateRequest.java
@@ -1,0 +1,17 @@
+package com.journeyprint.payment.web.request;
+
+import com.journeyprint.payment.application.request.PaymentCreateServiceRequest;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record PaymentCreateRequest(
+        @NotNull Long profileId,
+        @NotBlank @Size(max = 30) String name,
+        @Size(max = 100) String description
+) {
+
+    public PaymentCreateServiceRequest toCommand() {
+        return new PaymentCreateServiceRequest(profileId, name, description);
+    }
+}

--- a/src/main/java/com/journeyprint/profile/domain/ProfileRepository.java
+++ b/src/main/java/com/journeyprint/profile/domain/ProfileRepository.java
@@ -1,0 +1,23 @@
+package com.journeyprint.profile.domain;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProfileRepository {
+
+    private List<Long> profiles = new ArrayList<>();
+
+    public Optional<Long> getById(Long id) {
+        return profiles.stream()
+                .filter(profileId -> profileId.equals(id))
+                .findFirst();
+    }
+
+    public Long save(Long id) {
+        profiles.add(id);
+        return id;
+    }
+}

--- a/src/test/java/com/journeyprint/JourneyprintApiTest.java
+++ b/src/test/java/com/journeyprint/JourneyprintApiTest.java
@@ -1,0 +1,19 @@
+package com.journeyprint;
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public abstract class JourneyprintApiTest {
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    void setPort() {
+        RestAssured.port = port;
+    }
+
+}

--- a/src/test/java/com/journeyprint/payment/web/PaymentsApiPostSpecs.java
+++ b/src/test/java/com/journeyprint/payment/web/PaymentsApiPostSpecs.java
@@ -1,0 +1,157 @@
+package com.journeyprint.payment.web;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.journeyprint.JourneyprintApiTest;
+import com.journeyprint.payment.web.request.PaymentCreateRequest;
+import com.journeyprint.profile.domain.ProfileRepository;
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+
+@DisplayName("/api/payments")
+class PaymentsApiPostSpecs extends JourneyprintApiTest {
+
+    @Autowired
+    ProfileRepository profileRepository;
+
+    @Test
+    void 올바르게_요청하면_204_No_Content_상태코드를_반환한다() {
+        // Arrange
+        var profileId = 1L;
+        profileRepository.save(profileId);
+
+        PaymentCreateRequest request = new PaymentCreateRequest(
+                profileId,
+                "테스트 카드",
+                null
+        );
+
+        // Act
+        Response response = RestAssured.given()
+                .contentType("application/json")
+                .body(request)
+                .when()
+                .post("/api/payments");
+
+        // Assert
+        assertThat(response.getStatusCode()).isEqualTo(204);
+    }
+    
+    @Test
+    void profile_id_속성을_입력하지_않으면_400_Bad_Request_상태코드를_반환한다() {
+        // Arrange
+        PaymentCreateRequest request = new PaymentCreateRequest(
+                null,
+                "테스트 카드",
+                null
+        );
+        
+        // Act
+        Response response = RestAssured.given()
+                .contentType("application/json")
+                .body(request)
+                .when()
+                .post("/api/payments");
+        
+        // Assert
+        assertThat(response.getStatusCode()).isEqualTo(400);
+    }
+    
+    @Test
+    void profile_id_에_해당하는_사용자가_존재하지_않으면_400_Bad_Request_상태코드를_반환한다() {
+        // Arrange
+        PaymentCreateRequest request = new PaymentCreateRequest(
+                9999L,
+                "테스트 카드",
+                null
+        );
+        
+        // Act
+        Response response = RestAssured.given()
+                .contentType("application/json")
+                .body(request)
+                .when()
+                .post("/api/payments");
+        
+        // Assert
+        assertThat(response.getStatusCode()).isEqualTo(400);
+    }
+    
+    @ParameterizedTest
+    @NullAndEmptySource
+    @ValueSource(strings = {"   ", "\t", "\n"})
+    void name_속성이_null_또는_빈_문자열이면_400_Bad_Request_상태코드를_반환한다(String name) {
+        // Arrange
+        var profileId = 1L;
+        profileRepository.save(profileId);
+
+        PaymentCreateRequest request = new PaymentCreateRequest(
+                profileId,
+                name,
+                null
+        );
+
+        // Act
+        Response response = RestAssured.given()
+                .contentType("application/json")
+                .body(request)
+                .when()
+                .post("/api/payments");
+
+        // Assert
+        assertThat(response.getStatusCode()).isEqualTo(400);
+    }
+
+    @Test
+    void name_속성이_30자를_초과하면_400_Bad_Request_상태코드를_반환한다() {
+        // Arrange
+        var profileId = 1L;
+        profileRepository.save(profileId);
+
+        PaymentCreateRequest request = new PaymentCreateRequest(
+                profileId,
+                "1234567890123456789012345678901",
+                null
+        );
+
+        // Act
+        Response response = RestAssured.given()
+                .contentType("application/json")
+                .body(request)
+                .when()
+                .post("/api/payments");
+
+        // Assert
+        assertThat(response.getStatusCode()).isEqualTo(400);
+    }
+    
+    @Test
+    void description_속성이_100자를_초과하면_400_Bad_Request_상태코드를_반환한다() {
+        // Arrange
+        var profileId = 1L;
+        profileRepository.save(profileId);
+
+        PaymentCreateRequest request = new PaymentCreateRequest(
+                profileId,
+                "테스트 카드",
+                "a".repeat(101)
+        );
+
+        // Act
+        Response response = RestAssured.given()
+                .contentType("application/json")
+                .body(request)
+                .when()
+                .post("/api/payments");
+
+        // Assert
+        assertThat(response.getStatusCode()).isEqualTo(400);
+    }
+
+}


### PR DESCRIPTION
## 주요 변경 내용

- API 글로벌 예외 처리를 구성 하였습니다.
- API 응답 값을 재사용할 수 있는 객체를 구성 하였습니다.
- 사용자가 자산을 관리할 수 있도록 엔티티를 구성 하였습니다.
- 임시로 프로필에 대한 데이터 접근 계층을 생성하여 사용자 등록 여부를 검증합니다.

---

참고 자료
<img width="1535" height="408" alt="image" src="https://github.com/user-attachments/assets/af919890-edc2-4add-bce2-f487d31964ae" />

- [ERD](https://dbdiagram.io/d/여정-프로젝트-ERD-6958b86339fa3db27b003100)

## 🙋‍♂️ 리뷰 요청 포인트

사용자 인증은 추후에 개발하고, 우선 최소 기능을 중점적으로 다루어 첫번째 티켓을 "자산 등록" 으로 지정하였습니다.


1. 사용자 자산을 등록하기 위한 테스트 시나리오가 적절하게 이루어졌다고 판단할 수 있을까요?
2. 정상적으로 등록 되었다는 응답에 데이터를 포함하지 않아, 서비스 계층이 아무런 값을 반환하지 않습니다. 최소한의 `자산 정보를 조회할 수 있는 URL` 또는 `등록된 자산 고유 키` 같은 응답 값을 주어야 했을까요?

이상입니다. 잘 부탁드립니다 🙇🏻‍♂️